### PR TITLE
Remove Unecessary Variable Assignments

### DIFF
--- a/packet/member.py
+++ b/packet/member.py
@@ -2,10 +2,12 @@ from .models import Freshman, FreshSignature, UpperSignature, MiscSignature
 
 
 def signed_packets(member):
-    is_freshman = Freshman.query.filter_by(rit_username=member).first() is not None
-    if is_freshman:
+    
+    # Checks to see if member is a freshman 
+    if Freshman.query.filter_by(rit_username=member).first() is not None:
         return FreshSignature.query.filter_by(freshman_username=member, signed=True).all()
-    is_upper = UpperSignature.query.filter_by(member=member).first() is not None
-    if is_upper:
+    
+    # Checks to see if member is an upper_classmen
+    if UpperSignature.query.filter_by(member=member).first() is not None:
         return UpperSignature.query.filter_by(member=member, signed=True).all()
     return MiscSignature.query.filter_by(member=member).all()


### PR DESCRIPTION
This file wasted memory by assigning a boolean that it only ever checks once directly below it. It also did nothing to reduce the length of the line for style either, in fact 'if' is shorter than the variable name. Comments now provide readability.