### PR TITLE
Remove unecessary memory usage

### DIFF
--- a/packet/member.py
+++ b/packet/member.py
@@ -2,10 +2,10 @@ from .models import Freshman, FreshSignature, UpperSignature, MiscSignature
 
 
 def signed_packets(member):
-    is_freshman = Freshman.query.filter_by(rit_username=member).first() is not None
-    if is_freshman:
+    # Checks whether or not member is a freshman
+    if Freshman.query.filter_by(rit_username=member).first() is not None:
         return FreshSignature.query.filter_by(freshman_username=member, signed=True).all()
-    is_upper = UpperSignature.query.filter_by(member=member).first() is not None
-    if is_upper:
+    # Checks whether or not member is an upperclassman
+    if UpperSignature.query.filter_by(member=member).first() is not None:
         return UpperSignature.query.filter_by(member=member, signed=True).all()
     return MiscSignature.query.filter_by(member=member).all()


### PR DESCRIPTION
member.py assigned a variable to a rvalue that is only ever checked
once, directly below it. It did nothing to cut down on the line length,
in fact it created a new, longer line. Readability is now supplied
through comments, and memory is not wasted every time that
signed_packets() is ran