### PR TITLE
Show 'no packets' alert on upperclassmen page when there are no active packets

### DIFF
--- a/packet/templates/upperclassmen_totals.html
+++ b/packet/templates/upperclassmen_totals.html
@@ -9,42 +9,48 @@
         </div>
 
         <div id="eval-blocks">
-            <div id="eval-table">
-                <div class="card">
-                    <div class="card-body table-fill">
-                        <div class="table-responsive">
-                            <table class="table table-striped no-bottom-margin" data-module="table"
-                                   data-searchable="true" data-sort-column="1" data-sort-order="asc"
-                                   data-length-changable="true" data-paginated="false">
-                                <thead>
-                                <tr>
-                                    <th>Upperclassman</th>
-                                    <th>Signatures</th>
-                                </tr>
-                                </thead>
-                                <tbody>
-                                {% for member, signed_count in upperclassmen %}
+            {% if num_open_packets > 0 %}
+                <div id="eval-table">
+                    <div class="card">
+                        <div class="card-body table-fill">
+                            <div class="table-responsive">
+                                <table class="table table-striped no-bottom-margin" data-module="table"
+                                       data-searchable="true" data-sort-column="1" data-sort-order="asc"
+                                       data-length-changable="true" data-paginated="false">
+                                    <thead>
                                     <tr>
-                                        <td>
-                                            <a href="{{ url_for("upperclassman", uid=member) }}">
-                                                <img class="eval-user-img"
-                                                     alt="{{ member }}"
-                                                     src="https://profiles.csh.rit.edu/image/{{ member }}"
-                                                     width="25"
-                                                     height="25"/> {{ get_csh_name(member) }}
-                                            </a>
-                                        </td>
-                                        <td>
-                                            {{ signed_count }}/{{ num_open_packets }}
-                                        </td>
+                                        <th>Upperclassman</th>
+                                        <th>Signatures</th>
                                     </tr>
-                                {% endfor %}
-                                </tbody>
-                            </table>
+                                    </thead>
+                                    <tbody>
+                                    {% for member, signed_count in upperclassmen %}
+                                        <tr>
+                                            <td>
+                                                <a href="{{ url_for("upperclassman", uid=member) }}">
+                                                    <img class="eval-user-img"
+                                                         alt="{{ member }}"
+                                                         src="https://profiles.csh.rit.edu/image/{{ member }}"
+                                                         width="25"
+                                                         height="25"/> {{ get_csh_name(member) }}
+                                                </a>
+                                            </td>
+                                            <td>
+                                                {{ signed_count }}/{{ num_open_packets }}
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
+            {% else %}
+                <div class="alert alert-info" role="alert">
+                    There are currently no active packets.
+                </div>
+            {% endif %}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Currently, the main packet page displays this with there's no active packets:
![image](https://user-images.githubusercontent.com/5818258/47759536-7f0bac80-dc86-11e8-9874-f2fe337e8260.png)
But, the Upperclassmen total page shows an empty table:
![image](https://user-images.githubusercontent.com/5818258/47759550-8af76e80-dc86-11e8-9ffa-83416a8434f6.png)

I added a similar check to make sure that there's packets before showing the table, and if not, display the same alert as the main page.

This should probably be tested before merging, as I don't have the creds (DB, OIDC, etc.) to test it locally.