### PR TITLE
add the persons name to the packet confirmation screen

### DIFF
--- a/packet/static/js/signing.js
+++ b/packet/static/js/signing.js
@@ -13,7 +13,7 @@ $(document).ready(function () {
         var userData = $("#userInfo").val();
         dialogs.fire({
             title: "Are you sure?",
-            text: "Once a packet is signed it can only be unsigned from request to the Evals Director",
+            text: "Once " + packetData.freshman_name + "'s packet is signed it can only be unsigned from request to the Evals Director",
             type: "warning",
             confirmButtonText: 'Sign',
             showCancelButton: true,


### PR DESCRIPTION
quick fix for #169, although im not 100% sure if `packetData.freshman_name` is a full name or just a first name so I just reused the same format as https://github.com/ComputerScienceHouse/packet/blob/b7612dec8645e5c0a3a08eb1b6693cfba97a541d/packet/static/js/signing.js#L30