### PR TITLE
Strip whitespace from fields pulled from csv

### DIFF
--- a/packet/commands.py
+++ b/packet/commands.py
@@ -33,9 +33,9 @@ packet_end_time = time(hour=21)
 
 class CSVFreshman:
     def __init__(self, row):
-        self.name = row[0]
-        self.rit_username = row[3]
-        self.onfloor = row[1] == 'TRUE'
+        self.name = row[0].strip()
+        self.rit_username = row[3].strip()
+        self.onfloor = row[1].strip() == 'TRUE'
 
 
 def parse_csv(freshmen_csv):


### PR DESCRIPTION
Whitespace is often used to make CSVs prettier, or human readable, but parsing the CSV parses that whitespace too. We don't need that whitespace, and in fact it causes errors, so get rid of it.