### PR TITLE
Update pylint command in readme, gulp, and add docker to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
 python:
   - "3.7"
+services:
+  - "docker"
 
 install:
   - "pip install -r requirements.txt"
 script:
   - "pylint --load-plugins pylint_quotes packet/routes packet"
+  - "docker build -t packet ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ services:
 
 install:
   - "pip install -r requirements.txt"
+  - "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash"
+  - "nvm install"
+  - "nvm use"
+  - "npm install -g gulp"
+  - "npm install"
 script:
-  - "pylint --load-plugins pylint_quotes packet/routes packet"
+  - "gulp lint"
   - "docker build -t packet ."

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ fail blocking you from merging. To make your life easier just run it before maki
 
 To run pylint use this command:
 ```bash
-pylint packet
+pylint --load-plugins  pylint_quotes packet/routes packet
 ```
 
 All python files should have a top-level docstring explaining the contents of the file and complex functions should 

--- a/gulpfile.js/index.js
+++ b/gulpfile.js/index.js
@@ -19,4 +19,5 @@ requireDir('./tasks', {recurse: true});
 
 // Default task
 gulp.task('default', gulp.parallel('css', 'js'));
-gulp.task('production', gulp.parallel('css', 'js', 'generate-favicon', 'pylint'));
+gulp.task('production', gulp.parallel('css', 'js', 'generate-favicon'));
+gulp.task('lint', gulp.parallel('pylint'));

--- a/gulpfile.js/tasks/pylint.js
+++ b/gulpfile.js/tasks/pylint.js
@@ -2,7 +2,7 @@ const gulp = require('gulp');
 const exec = require('child_process').exec;
 
 let pylintTask = (cb) => {
-    exec('pylint packet', function (err, stdout, stderr) {
+    exec('pylint --load-plugins pylint_quotes packet/routes packet', function (err, stdout, stderr) {
         console.log(stdout);
         console.log(stderr);
         cb(err);


### PR DESCRIPTION
- Expand pylint documentation to match travis command so contributors are less likely to experience surprise travis failures.
- Update the pylint task in gulp to match what we generally run.
- Add docker build to travis to check that the image will build.