### PR TITLE
Aggregate Signatures over time graph

### DIFF
--- a/packet/routes/api.py
+++ b/packet/routes/api.py
@@ -17,6 +17,7 @@ from packet.utils import before_request, packet_auth, notify_slack
 from packet.models import Packet, MiscSignature, NotificationSubscription, Freshman, FreshSignature, UpperSignature
 from packet.notifications import packet_signed_notification, packet_100_percent_notification, \
         packet_starting_notification, packets_starting_notification
+import packet.stats as stats
 
 
 @app.route('/api/v1/freshmen', methods=['POST'])
@@ -255,80 +256,13 @@ def report(info):
 @app.route('/api/v1/stats/packet/<packet_id>')
 @packet_auth
 def packet_stats(packet_id):
-    packet = Packet.by_id(packet_id)
-
-    dates = [packet.start.date() + timedelta(days=x) for x in range(0, (packet.end-packet.start).days + 1)]
-
-    print(dates)
-
-    upper_stats = {date: list() for date in dates}
-    for uid, date in map(lambda sig: (sig.member, sig.updated),
-                         filter(lambda sig: sig.signed, packet.upper_signatures)):
-        upper_stats[date.date()].append(uid)
-
-    fresh_stats = {date: list() for date in dates}
-    for username, date in map(lambda sig: (sig.freshman_username, sig.updated),
-                              filter(lambda sig: sig.signed, packet.fresh_signatures)):
-        fresh_stats[date.date()].append(username)
-
-    misc_stats = {date: list() for date in dates}
-    for uid, date in map(lambda sig: (sig.member, sig.updated), packet.misc_signatures):
-        misc_stats[date.date()].append(uid)
-
-    total_stats = dict()
-    for date in dates:
-        total_stats[date.isoformat()] = {
-                'upper': upper_stats[date],
-                'fresh': fresh_stats[date],
-                'misc': misc_stats[date],
-                }
-
-    return {
-            'packet_id': packet_id,
-            'dates': total_stats,
-            }
-
-
-def sig2dict(sig):
-    """
-    A utility function for upperclassman stats.
-    Converts an UpperSignature to a dictionary with the date and the packet.
-    """
-    packet = Packet.by_id(sig.packet_id)
-    return {
-            'date': sig.updated.date(),
-            'packet': {
-                'id': packet.id,
-                'freshman_username': packet.freshman_username,
-                },
-            }
+    return stats.packet_stats(packet_id)
 
 
 @app.route('/api/v1/stats/upperclassman/<uid>')
 @packet_auth
 def upperclassman_stats(uid):
-
-    sigs = UpperSignature.query.filter(
-            UpperSignature.signed,
-            UpperSignature.member == uid
-            ).all() + MiscSignature.query.filter(MiscSignature.member == uid).all()
-
-    sig_dicts = list(map(sig2dict, sigs))
-
-    dates = set(map(lambda sd: sd['date'], sig_dicts))
-
-    return {
-            'member': uid,
-            'signatures': {
-                date.isoformat() : list(
-                    map(lambda sd: sd['packet'],
-                        filter(lambda sig, d=date: sig['date'] == d,
-                            sig_dicts
-                            )
-                        )
-                    ) for date in dates
-                }
-            }
+    return stats.upperclassman_stats(uid)
 
 def commit_sig(packet, was_100, uid):
     packet_signed_notification(packet, uid)

--- a/packet/stats.py
+++ b/packet/stats.py
@@ -1,0 +1,113 @@
+from datetime import timedelta
+
+from packet.models import Packet, MiscSignature, UpperSignature
+
+
+def packet_stats(packet_id):
+    """
+    Gather statistics for a packet in the form of number of signatures per day
+
+    Return format: {
+        packet_id,
+        freshman: {
+            name,
+            rit_username,
+        },
+        dates: {
+           <date>: {
+                upper: [ uid ],
+                misc: [ uid ],
+                fresh: [ freshman_username ],
+           },
+        },
+    }
+    """
+    packet = Packet.by_id(packet_id)
+
+    dates = [packet.start.date() + timedelta(days=x) for x in range(0, (packet.end-packet.start).days + 1)]
+
+    print(dates)
+
+    upper_stats = {date: list() for date in dates}
+    for uid, date in map(lambda sig: (sig.member, sig.updated),
+                         filter(lambda sig: sig.signed, packet.upper_signatures)):
+        upper_stats[date.date()].append(uid)
+
+    fresh_stats = {date: list() for date in dates}
+    for username, date in map(lambda sig: (sig.freshman_username, sig.updated),
+                              filter(lambda sig: sig.signed, packet.fresh_signatures)):
+        fresh_stats[date.date()].append(username)
+
+    misc_stats = {date: list() for date in dates}
+    for uid, date in map(lambda sig: (sig.member, sig.updated), packet.misc_signatures):
+        misc_stats[date.date()].append(uid)
+
+    total_stats = dict()
+    for date in dates:
+        total_stats[date.isoformat()] = {
+                'upper': upper_stats[date],
+                'fresh': fresh_stats[date],
+                'misc': misc_stats[date],
+                }
+
+    return {
+            'packet_id': packet_id,
+            'freshman': {
+                'name': packet.freshman.name,
+                'rit_username': packet.freshman.rit_username,
+                },
+            'dates': total_stats,
+            }
+
+
+def sig2dict(sig):
+    """
+    A utility function for upperclassman stats.
+    Converts an UpperSignature to a dictionary with the date and the packet.
+    """
+    packet = Packet.by_id(sig.packet_id)
+    return {
+            'date': sig.updated.date(),
+            'packet': {
+                'id': packet.id,
+                'freshman_username': packet.freshman_username,
+                },
+            }
+
+
+def upperclassman_stats(uid):
+    """
+    Gather statistics for an upperclassman's signature habits
+
+    Return format: {
+        member: <uid>,
+        signautes: {
+            <date>: [{
+                id: <packet_id>,
+                freshman_username,
+            }],
+        },
+    }
+    """
+
+    sigs = UpperSignature.query.filter(
+            UpperSignature.signed,
+            UpperSignature.member == uid
+            ).all() + MiscSignature.query.filter(MiscSignature.member == uid).all()
+
+    sig_dicts = list(map(sig2dict, sigs))
+
+    dates = set(map(lambda sd: sd['date'], sig_dicts))
+
+    return {
+            'member': uid,
+            'signatures': {
+                date.isoformat() : list(
+                    map(lambda sd: sd['packet'],
+                        filter(lambda sig, d=date: sig['date'] == d,
+                            sig_dicts
+                            )
+                        )
+                    ) for date in dates
+                }
+            }

--- a/packet/templates/packet.html
+++ b/packet/templates/packet.html
@@ -22,6 +22,13 @@
                     {% endif %}
                 </div>
             </div>
+            <div class="row w-100 mb-1">
+                {% if info.realm == "csh" %}
+                <div class="col">
+                    <a class="btn btn-primary" style="float: right" href="{{ url_for('packet_graphs', packet_id=packet.id) }}">Graphs</a>
+                </div>
+                {% endif %}
+            </div>
             <div class="row">
                 <div class="col ml-1 mb-1">
                     <h6>Signatures: <span class="badge badge-secondary">{{ received.total }}/{{ required.total }}</span></h6>

--- a/packet/templates/packet_stats.html
+++ b/packet/templates/packet_stats.html
@@ -8,7 +8,19 @@
 {% block body %}
 <div class="container main">
     <div class="card">
-        <h5 class="card-header bg-primary text-white">Cumulative Signatures Over Time for {{ fresh['name'] }} ({{ fresh['rit_username'] }})</h5>
+        <h5 class="card-header bg-primary text-white">Cumulative Signatures Over Time for 
+            <a class="text-white" href="{{ url_for('freshman_packet', packet_id=packet.id) }}">
+                    <img class="eval-user-img"
+                         alt="{{ get_rit_name(packet.freshman_username) }}"
+                         src="{{ get_rit_image(packet.freshman_username) }}"
+                         width="25"
+                         height="25"/> {{ get_rit_name(packet.freshman_username) }}
+                </a>
+</h5>
+        <tr>
+            <td data-priority="1">
+            </td>
+        </tr>
         <div class="card-body">
             <canvas id="myChart" width="400" height="400"></canvas>
             <script>

--- a/packet/templates/packet_stats.html
+++ b/packet/templates/packet_stats.html
@@ -1,0 +1,72 @@
+{% extends "extend/base.html" %}
+
+{% block head %}
+{{ super() }}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.3/Chart.bundle.min.js"></script>
+{% endblock %}
+
+{% block body %}
+<div class="container main">
+    <div class="card">
+        <h5 class="card-header bg-primary text-white">Cumulative Signatures Over Time for {{ fresh['name'] }} ({{ fresh['rit_username'] }})</h5>
+        <div class="card-body">
+            <canvas id="myChart" width="400" height="400"></canvas>
+            <script>
+var data = {{ data|safe }};
+// Stack the lines
+var ctx = document.getElementById('myChart');
+var myChart = new Chart(ctx, {
+    type: 'line',
+    data: {
+        labels: data.dates,
+        datasets: [
+            {
+                fill: 'origin',
+                label: 'Fresh Sigs',
+                data: data.accum.fresh,
+                backgroundColor: '#b0197e80',
+                borderColor: '#b0197e',
+                borderWidth: 1,
+                lineTension: 0
+            },
+            {
+                fill: '-1',
+                label: 'Misc Sigs',
+                data: data.accum.misc,
+                backgroundColor: '#0000ff80',
+                borderColor: 'blue',
+                borderWidth: 1,
+                lineTension: 0
+            },
+            {
+                fill: '-1',
+                label: 'Upper Sigs',
+                data: data.accum.upper,
+                backgroundColor: '#00ff0080',
+                borderColor: 'green',
+                borderWidth: 1,
+                lineTension: 0
+            }
+        ]
+    },
+    options: {
+        scales: {
+            xAxes: [{
+                type: 'time',
+                time: {
+                    unit: 'day',
+                },
+            }],
+            yAxes: [{
+                ticks: {
+                    beginAtZero: true
+                }
+            }]
+        }
+    }
+});
+            </script>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## I'm making graphs
This is a step toward part 2 of #62 

Graphs are reachable from a packet page, via a new button under the sign button.
![Graphs button](https://user-images.githubusercontent.com/12436574/90327027-90a66d00-df5d-11ea-9493-8cec931833db.png)
This button is only shown to users in the csh realm.

#### Graph 1: Aggregate Signature over time
`/stats/packet/<packet_id>`
![Graph of aggregate signatures over time for packet id 1 in packet-dev](https://user-images.githubusercontent.com/12436574/90273974-cc421980-de2d-11ea-89d2-271ba5dfe0da.png)

The graph also links back to the packet it shows, in the same format as the packet list
![Graph title showing new link back to packet](https://user-images.githubusercontent.com/12436574/90327148-9fd9ea80-df5e-11ea-9a19-9dea514b6e9b.png)
