### PR TITLE
Add time to packet end dates

### DIFF
--- a/packet/templates/packet.html
+++ b/packet/templates/packet.html
@@ -1,6 +1,6 @@
 {% extends "extend/base.html" %}
 
-{% set packet_end = packet.end.strftime('%m/%d/%Y') %}
+{% set packet_end = packet.end.strftime('%m/%d/%Y, %H:%M') %}
 
 {% block body %}
     <div class="container main">


### PR DESCRIPTION
Sets date format to `month/day/year, HH:MM`

~~I haven't tested this (experimenting with github codespaces, and don't have the local dev config
setup to support that yet), but it's a small enough change that I'm not concerned to merge it.~~
Tested locally: 
![Screenshot of packet end date badge. The text reads "Ends: 10/02/2020, 21:00"](https://user-images.githubusercontent.com/12436574/93684722-6aed1600-fa7d-11ea-8198-6d8d219fe53c.png)


(Also the github cli is pretty nice)
