### PR TITLE
Require fewer secrets for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ If it doesn't work for some reason, you may have to globally install gulp throug
 npm install -g gulp
 ```
 
+### Local Development
+* PostgreSQL
+You'll need a postgres instance to use as a development DB.
+You can use an existing database, like the instance used for the dev branch, use a database on another server, or spin up a container using docker or podman. 
+To get setup using docker, run
+```bash
+docker run --name packet-postgres -e POSTGRES_PASSWORD=mysecretpassword -d -p 5432:5432 postgres
+```
+After the container starts up, you should be able to connect with the connection string `postgresql://postgres:mysecretpassword@localhost:5432/postgres`, which is the default connection string in `config.env.py`.
+Once the container is up, run the following to set up the database tables.
+```bash
+flask db upgrade
+```
+
 ### Secrets and configuration
 Packet supports 2 primary configuration methods:
 1. Environment variables - See `config.env.py` for the expected names and default values.

--- a/config.env.py
+++ b/config.env.py
@@ -31,6 +31,19 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 # LDAP config
 LDAP_BIND_DN = environ.get("PACKET_LDAP_BIND_DN", None)
 LDAP_BIND_PASS = environ.get("PACKET_LDAP_BIND_PASS", None)
+LDAP_MOCK_MEMBERS = [
+        {'uid':'evals', 'groups': ['eboard', 'eboard-evaluations', 'active']},
+        {'uid':'imps-3da', 'groups': ['eboard', 'eboard-imps', '3da', 'active']},
+        {
+            'uid':'rtp-cm-webs-onfloor',
+            'groups': ['active-rtp', 'rtp', 'constitutional_maintainers', 'webmaster', 'active', 'onfloor'],
+            'room_number': 1024
+        },
+        {'uid':'misc-rtp', 'groups': ['rtp']},
+        {'uid':'onfloor', 'groups': ['active', 'onfloor'], 'room_number': 1024},
+        {'uid':'active-offfloor', 'groups': ['active']},
+        {'uid':'alum', 'groups': ['member']},
+    ]
 
 # Mail Config
 MAIL_PROD = strtobool(environ.get("PACKET_MAIL_PROD", "False"))

--- a/config.env.py
+++ b/config.env.py
@@ -3,7 +3,7 @@ Default configuration settings and environment variable based configuration logi
     See the readme for more information
 """
 from distutils.util import strtobool
-from os import environ
+from os import environ, path, getcwd
 
 # Flask config
 DEBUG = False
@@ -25,7 +25,7 @@ OIDC_CLIENT_ID = environ.get("PACKET_OIDC_CLIENT_ID", "packet")
 OIDC_CLIENT_SECRET = environ.get("PACKET_OIDC_CLIENT_SECRET", "PLEASE_REPLACE_ME")
 
 # SQLAlchemy config
-SQLALCHEMY_DATABASE_URI = environ.get("PACKET_DATABASE_URI", None)
+SQLALCHEMY_DATABASE_URI = environ.get("PACKET_DATABASE_URI", "postgresql://postgres:mysecretpassword@localhost:5432/postgres")
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 # LDAP config

--- a/packet/__init__.py
+++ b/packet/__init__.py
@@ -61,9 +61,6 @@ intro_onesignal_client = onesignal.Client(user_auth_key=app.config['ONESIGNAL_US
 # OIDC Auth
 auth = OIDCAuthentication({'app': APP_CONFIG}, app)
 
-# LDAP
-_ldap = csh_ldap.CSHLDAP(app.config['LDAP_BIND_DN'], app.config['LDAP_BIND_PASS'])
-
 # Sentry
 sentry_sdk.init(
     dsn=app.config['SENTRY_DSN'],
@@ -73,6 +70,7 @@ sentry_sdk.init(
 app.logger.info('OIDCAuth and LDAP configured')
 
 # pylint: disable=wrong-import-position
+from .ldap import ldap
 from . import models
 from . import context_processors
 from . import commands

--- a/packet/__init__.py
+++ b/packet/__init__.py
@@ -50,13 +50,25 @@ APP_CONFIG = ProviderConfiguration(issuer=app.config['OIDC_ISSUER'],
                                                             app.config['OIDC_CLIENT_SECRET']))
 
 # Initialize Onesignal Notification apps
-csh_onesignal_client = onesignal.Client(user_auth_key=app.config['ONESIGNAL_USER_AUTH_KEY'],
-                                    app_auth_key=app.config['ONESIGNAL_CSH_APP_AUTH_KEY'],
-                                    app_id=app.config['ONESIGNAL_CSH_APP_ID'])
+csh_onesignal_client = None
+if app.config['ONESIGNAL_USER_AUTH_KEY'] and \
+   app.config['ONESIGNAL_CSH_APP_AUTH_KEY'] and \
+   app.config['ONESIGNAL_CSH_APP_ID']:
+    csh_onesignal_client = onesignal.Client(
+        user_auth_key=app.config['ONESIGNAL_USER_AUTH_KEY'],
+        app_auth_key=app.config['ONESIGNAL_CSH_APP_AUTH_KEY'],
+        app_id=app.config['ONESIGNAL_CSH_APP_ID']
+    )
 
-intro_onesignal_client = onesignal.Client(user_auth_key=app.config['ONESIGNAL_USER_AUTH_KEY'],
-                                    app_auth_key=app.config['ONESIGNAL_INTRO_APP_AUTH_KEY'],
-                                    app_id=app.config['ONESIGNAL_INTRO_APP_ID'])
+intro_onesignal_client = None
+if app.config['ONESIGNAL_USER_AUTH_KEY'] and \
+   app.config['ONESIGNAL_INTRO_APP_AUTH_KEY'] and \
+   app.config['ONESIGNAL_INTRO_APP_ID']:
+    intro_onesignal_client = onesignal.Client(
+        user_auth_key=app.config['ONESIGNAL_USER_AUTH_KEY'],
+        app_auth_key=app.config['ONESIGNAL_INTRO_APP_AUTH_KEY'],
+        app_id=app.config['ONESIGNAL_INTRO_APP_ID']
+    )
 
 # OIDC Auth
 auth = OIDCAuthentication({'app': APP_CONFIG}, app)

--- a/packet/__init__.py
+++ b/packet/__init__.py
@@ -59,6 +59,7 @@ if app.config['ONESIGNAL_USER_AUTH_KEY'] and \
         app_auth_key=app.config['ONESIGNAL_CSH_APP_AUTH_KEY'],
         app_id=app.config['ONESIGNAL_CSH_APP_ID']
     )
+    app.logger.info('CSH Onesignal configured and notifications enabled')
 
 intro_onesignal_client = None
 if app.config['ONESIGNAL_USER_AUTH_KEY'] and \
@@ -69,9 +70,11 @@ if app.config['ONESIGNAL_USER_AUTH_KEY'] and \
         app_auth_key=app.config['ONESIGNAL_INTRO_APP_AUTH_KEY'],
         app_id=app.config['ONESIGNAL_INTRO_APP_ID']
     )
+    app.logger.info('Intro Onesignal configured and notifications enabled')
 
 # OIDC Auth
 auth = OIDCAuthentication({'app': APP_CONFIG}, app)
+app.logger.info('OIDCAuth configured')
 
 # Sentry
 sentry_sdk.init(
@@ -79,7 +82,6 @@ sentry_sdk.init(
     integrations=[FlaskIntegration(), SqlalchemyIntegration()]
 )
 
-app.logger.info('OIDCAuth and LDAP configured')
 
 # pylint: disable=wrong-import-position
 from .ldap import ldap

--- a/packet/context_processors.py
+++ b/packet/context_processors.py
@@ -6,16 +6,15 @@ import urllib
 from functools import lru_cache
 from datetime import datetime
 
-from packet.ldap import ldap_get_member
 from packet.models import Freshman
-from packet import app
+from packet import app, ldap
 
 
 # pylint: disable=bare-except
 @lru_cache(maxsize=128)
 def get_csh_name(username):
     try:
-        member = ldap_get_member(username)
+        member = ldap.get_member(username)
         return member.cn + ' (' + member.uid + ')'
     except:
         return username

--- a/packet/ldap.py
+++ b/packet/ldap.py
@@ -39,6 +39,10 @@ class LDAPWrapper:
     def __init__(self, cshldap=None, mock_members=None):
         self.ldap = cshldap
         self.mock_members = mock_members
+        if self.ldap:
+            app.logger.info('LDAP configured with CSH LDAP')
+        else:
+            app.logger.info('LDAP configured with local mock')
 
 
     def _get_group_members(self, group):

--- a/packet/ldap.py
+++ b/packet/ldap.py
@@ -5,197 +5,256 @@ Helper functions for working with the csh_ldap library
 from functools import lru_cache
 from datetime import date
 
-from packet import _ldap
+from csh_ldap import CSHLDAP
+
+from packet import app
 
 
-def _ldap_get_group_members(group):
-    """
-    :return: A list of CSHMember instances
-    """
-    return _ldap.get_group(group).get_members()
+class MockMember:
+
+    def __init__(self, uid: str, groups: list = None, cn: str = None, room_number: int = None):
+        self.uid = uid
+        self.groups = groups if groups else list()
+        if room_number:
+            self.room_number = room_number
+        self.cn = cn if cn else uid.title() # pylint: disable=invalid-name
 
 
-def _ldap_is_member_of_group(member, group):
-    """
-    :param member: A CSHMember instance
-    """
-    for group_dn in member.get('memberOf'):
-        if group == group_dn.split(',')[0][3:]:
-            return True
-
-    return False
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return self.uid == other.uid
+        return False
 
 
-# Getters
-
-@lru_cache(maxsize=256)
-def ldap_get_member(username):
-    """
-    :return: A CSHMember instance
-    """
-    return _ldap.get_member(username, uid=True)
+    def __hash__(self):
+        return hash(self.uid)
 
 
-def ldap_get_active_members():
-    """
-    Gets all current, dues-paying members
-    :return: A list of CSHMember instances
-    """
-    return _ldap_get_group_members('active')
+    def __repr__(self):
+        return f'MockMember(uid: {self.uid}, groups: {self.groups})'
 
 
-def ldap_get_intro_members():
-    """
-    Gets all freshmen members
-    :return: A list of CSHMember instances
-    """
-    return _ldap_get_group_members('intromembers')
+class LDAPWrapper:
+
+    def __init__(self, cshldap=None, mock_members=None):
+        self.ldap = cshldap
+        self.mock_members = mock_members
 
 
-def ldap_get_eboard():
-    """
-    Gets all voting members of eboard
-    :return: A list of CSHMember instances
-    """
-    members = _ldap_get_group_members('eboard-chairman') + _ldap_get_group_members('eboard-evaluations'
-        ) + _ldap_get_group_members('eboard-financial') + _ldap_get_group_members('eboard-history'
-        ) + _ldap_get_group_members('eboard-imps') + _ldap_get_group_members('eboard-opcomm'
-        ) + _ldap_get_group_members('eboard-research') + _ldap_get_group_members('eboard-social'
-        )
-
-    return members
+    def _get_group_members(self, group):
+        """
+        :return: A list of CSHMember instances
+        """
+        if self.ldap:
+            return self.ldap.get_group(group).get_members()
+        else:
+            return list(filter(lambda member: group in member.groups, self.mock_members))
 
 
-def ldap_get_live_onfloor():
-    """
-    All upperclassmen who live on floor and are not eboard
-    :return: A list of CSHMember instances
-    """
-    members = []
-    onfloor = _ldap_get_group_members('onfloor')
-    for member in onfloor:
-        if ldap_get_roomnumber(member) and not ldap_is_eboard(member):
-            members.append(member)
-
-    return members
-
-
-def ldap_get_active_rtps():
-    """
-    All active RTPs
-    :return: A list of CSHMember instances
-    """
-    return [member.uid for member in _ldap_get_group_members('active_rtp')]
+    def _is_member_of_group(self, member, group):
+        """
+        :param member: A CSHMember instance
+        """
+        if self.ldap:
+            for group_dn in member.get('memberOf'):
+                if group == group_dn.split(',')[0][3:]:
+                    return True
+            return False
+        else:
+            return group in member.groups
 
 
-def ldap_get_3das():
-    """
-    All 3das
-    :return: A list of CSHMember instances
-    """
-    return [member.uid for member in _ldap_get_group_members('3da')]
+    # Getters
+
+    @lru_cache(maxsize=256)
+    def get_member(self, username):
+        """
+        :return: A CSHMember instance
+        """
+        if self.ldap:
+            return self.ldap.get_member(username, uid=True)
+        else:
+            member = next(filter(lambda member: member.uid == username, self.mock_members), None)
+            if member:
+                return member
+            raise KeyError('Invalid Search Name')
 
 
-def ldap_get_webmasters():
-    """
-    All webmasters
-    :return: A list of CSHMember instances
-    """
-    return [member.uid for member in _ldap_get_group_members('webmaster')]
+    def get_active_members(self):
+        """
+        Gets all current, dues-paying members
+        :return: A list of CSHMember instances
+        """
+        return self._get_group_members('active')
 
 
-def ldap_get_constitutional_maintainers():
-    """
-    All constitutional maintainers
-    :return: A list of CSHMember instances
-    """
-    return [member.uid for member in _ldap_get_group_members('constitutional_maintainers')]
+    def get_intro_members(self):
+        """
+        Gets all freshmen members
+        :return: A list of CSHMember instances
+        """
+        return self._get_group_members('intromembers')
 
 
-def ldap_get_wiki_maintainers():
-    """
-    All wiki maintainers
-    :return: A list of CSHMember instances
-    """
-    return [member.uid for member in _ldap_get_group_members('wiki_maintainers')]
+    def get_eboard(self):
+        """
+        Gets all voting members of eboard
+        :return: A list of CSHMember instances
+        """
+        members = self._get_group_members('eboard-chairman') + self._get_group_members('eboard-evaluations'
+            ) + self._get_group_members('eboard-financial') + self._get_group_members('eboard-history'
+            ) + self._get_group_members('eboard-imps') + self._get_group_members('eboard-opcomm'
+            ) + self._get_group_members('eboard-research') + self._get_group_members('eboard-social'
+            )
+
+        return members
 
 
-def ldap_get_drink_admins():
-    """
-    All drink admins
-    :return: A list of CSHMember instances
-    """
-    return [member.uid for member in _ldap_get_group_members('drink')]
+    def get_live_onfloor(self):
+        """
+        All upperclassmen who live on floor and are not eboard
+        :return: A list of CSHMember instances
+        """
+        members = []
+        onfloor = self._get_group_members('onfloor')
+        for member in onfloor:
+            if self.get_roomnumber(member) and not self.is_eboard(member):
+                members.append(member)
+
+        return members
 
 
-def ldap_get_eboard_role(member):
-    """
-    :param member: A CSHMember instance
-    :return: A String or None
-    """
-
-    return_val = None
-
-    if _ldap_is_member_of_group(member, 'eboard-chairman'):
-        return_val = 'Chairperson'
-    elif _ldap_is_member_of_group(member, 'eboard-evaluations'):
-        return_val = 'Evals'
-    elif _ldap_is_member_of_group(member, 'eboard-financial'):
-        return_val = 'Financial'
-    elif _ldap_is_member_of_group(member, 'eboard-history'):
-        return_val = 'History'
-    elif _ldap_is_member_of_group(member, 'eboard-imps'):
-        return_val = 'Imps'
-    elif _ldap_is_member_of_group(member, 'eboard-opcomm'):
-        return_val = 'OpComm'
-    elif _ldap_is_member_of_group(member, 'eboard-research'):
-        return_val = 'R&D'
-    elif _ldap_is_member_of_group(member, 'eboard-social'):
-        return_val = 'Social'
-    elif _ldap_is_member_of_group(member, 'eboard-secretary'):
-        return_val = 'Secretary'
-
-    return return_val
+    def get_active_rtps(self):
+        """
+        All active RTPs
+        :return: A list of CSHMember instances
+        """
+        return [member.uid for member in self._get_group_members('active_rtp')]
 
 
-# Status checkers
-def ldap_is_eboard(member):
-    """
-    :param member: A CSHMember instance
-    """
-    return _ldap_is_member_of_group(member, 'eboard')
+    def get_3das(self):
+        """
+        All 3das
+        :return: A list of CSHMember instances
+        """
+        return [member.uid for member in self._get_group_members('3da')]
 
 
-def ldap_is_evals(member):
-    return _ldap_is_member_of_group(member, 'eboard-evaluations')
+    def get_webmasters(self):
+        """
+        All webmasters
+        :return: A list of CSHMember instances
+        """
+        return [member.uid for member in self._get_group_members('webmaster')]
 
 
-def ldap_is_rtp(member):
-    return _ldap_is_member_of_group(member, 'rtp')
+    def get_constitutional_maintainers(self):
+        """
+        All constitutional maintainers
+        :return: A list of CSHMember instances
+        """
+        return [member.uid for member in self._get_group_members('constitutional_maintainers')]
+
+    def get_wiki_maintainers(self):
+        """
+        All wiki maintainers
+        :return: A list of CSHMember instances
+        """
+        return [member.uid for member in self._get_group_members('wiki_maintainers')]
 
 
-def ldap_is_intromember(member):
-    """
-    :param member: A CSHMember instance
-    """
-    return _ldap_is_member_of_group(member, 'intromembers')
+    def get_drink_admins(self):
+        """
+        All drink admins
+        :return: A list of CSHMember instances
+        """
+        return [member.uid for member in self._get_group_members('drink')]
 
 
-def ldap_is_on_coop(member):
-    """
-    :param member: A CSHMember instance
-    """
-    if date.today().month > 6:
-        return _ldap_is_member_of_group(member, 'fall_coop')
-    else:
-        return _ldap_is_member_of_group(member, 'spring_coop')
+    def get_eboard_role(self, member):
+        """
+        :param member: A CSHMember instance
+        :return: A String or None
+        """
+
+        return_val = None
+
+        if self._is_member_of_group(member, 'eboard-chairman'):
+            return_val = 'Chairperson'
+        elif self._is_member_of_group(member, 'eboard-evaluations'):
+            return_val = 'Evals'
+        elif self._is_member_of_group(member, 'eboard-financial'):
+            return_val = 'Financial'
+        elif self._is_member_of_group(member, 'eboard-history'):
+            return_val = 'History'
+        elif self._is_member_of_group(member, 'eboard-imps'):
+            return_val = 'Imps'
+        elif self._is_member_of_group(member, 'eboard-opcomm'):
+            return_val = 'OpComm'
+        elif self._is_member_of_group(member, 'eboard-research'):
+            return_val = 'R&D'
+        elif self._is_member_of_group(member, 'eboard-social'):
+            return_val = 'Social'
+        elif self._is_member_of_group(member, 'eboard-secretary'):
+            return_val = 'Secretary'
+
+        return return_val
 
 
-def ldap_get_roomnumber(member):
-    """
-    :param member: A CSHMember instance
-    """
-    try:
-        return member.roomNumber
-    except AttributeError:
-        return None
+    # Status checkers
+    def is_eboard(self, member):
+        """
+        :param member: A CSHMember instance
+        """
+        return self._is_member_of_group(member, 'eboard')
+
+
+    def is_evals(self, member):
+        return self._is_member_of_group(member, 'eboard-evaluations')
+
+
+    def is_rtp(self, member):
+        return self._is_member_of_group(member, 'rtp')
+
+
+    def is_intromember(self, member):
+        """
+        :param member: A CSHMember instance
+        """
+        return self._is_member_of_group(member, 'intromembers')
+
+
+    def is_on_coop(self, member):
+        """
+        :param member: A CSHMember instance
+        """
+        if date.today().month > 6:
+            return self._is_member_of_group(member, 'fall_coop')
+        else:
+            return self._is_member_of_group(member, 'spring_coop')
+
+
+    def get_roomnumber(self, member): # pylint: disable=no-self-use
+        """
+        :param member: A CSHMember instance
+        """
+        try:
+            return member.roomNumber
+        except AttributeError:
+            return None
+
+
+if app.config['LDAP_BIND_DN'] and app.config['LDAP_BIND_PASS']:
+    ldap = LDAPWrapper(cshldap=CSHLDAP(app.config['LDAP_BIND_DN'],
+                                     app.config['LDAP_BIND_PASS']
+                                    )
+)
+else:
+    ldap = LDAPWrapper(
+            mock_members=list(
+                map(
+                    lambda mock_dict: MockMember(**mock_dict),
+                    app.config['LDAP_MOCK_MEMBERS']
+                   )
+                )
+            )

--- a/packet/log_utils.py
+++ b/packet/log_utils.py
@@ -5,9 +5,8 @@ General utilities for logging metadata
 from functools import wraps
 from datetime import datetime
 
-from packet import app
+from packet import app, ldap
 from packet.context_processors import get_rit_name
-from packet.ldap import ldap_get_member
 from packet.utils import is_freshman_on_floor
 
 
@@ -39,7 +38,7 @@ def _format_cache(func):
 
 
 # Tuple of lru_cache functions to log stats from
-_caches = (get_rit_name, ldap_get_member, is_freshman_on_floor)
+_caches = (get_rit_name, ldap.get_member, is_freshman_on_floor)
 
 
 def log_cache(func):

--- a/packet/notifications.py
+++ b/packet/notifications.py
@@ -11,6 +11,20 @@ post_body = {
     'url': app.config['PROTOCOL'] + app.config['SERVER_NAME']
 }
 
+def require_onesignal_intro(func):
+    def require_onesignal_intro_wrapper(*args, **kwargs):
+        if intro_onesignal_client:
+            return func(*args, **kwargs)
+        return None
+    return require_onesignal_intro_wrapper
+
+def require_onesignal_csh(func):
+    def require_onesignal_csh_wrapper(*args, **kwargs):
+        if csh_onesignal_client:
+            return func(*args, **kwargs)
+        return None
+    return require_onesignal_csh_wrapper
+
 
 def send_notification(notification_body, subscriptions, client):
     tokens = list(map(lambda subscription: subscription.token, subscriptions))
@@ -24,6 +38,7 @@ def send_notification(notification_body, subscriptions, client):
             app.logger.warn('The notification ({}) was unsuccessful'.format(notification.post_body))
 
 
+@require_onesignal_intro
 def packet_signed_notification(packet, signer):
     subscriptions = NotificationSubscription.query.filter_by(freshman_username=packet.freshman_username)
     if subscriptions:
@@ -36,6 +51,8 @@ def packet_signed_notification(packet, signer):
         send_notification(notification_body, subscriptions, intro_onesignal_client)
 
 
+@require_onesignal_csh
+@require_onesignal_intro
 def packet_100_percent_notification(packet):
     member_subscriptions = NotificationSubscription.query.filter(NotificationSubscription.member.isnot(None))
     intro_subscriptions = NotificationSubscription.query.filter(NotificationSubscription.freshman_username.isnot(None))
@@ -50,6 +67,7 @@ def packet_100_percent_notification(packet):
         send_notification(notification_body, intro_subscriptions, intro_onesignal_client)
 
 
+@require_onesignal_intro
 def packet_starting_notification(packet):
     subscriptions = NotificationSubscription.query.filter_by(freshman_username=packet.freshman_username)
     if subscriptions:
@@ -62,6 +80,7 @@ def packet_starting_notification(packet):
         send_notification(notification_body, subscriptions, intro_onesignal_client)
 
 
+@require_onesignal_csh
 def packets_starting_notification(start_date):
     member_subscriptions = NotificationSubscription.query.filter(NotificationSubscription.member.isnot(None))
     if member_subscriptions:


### PR DESCRIPTION
This PR gets most of the way to enabling secretless local development, but not quite. 

I haven't wrapped SSO to enable developing completely offline, but this PR adds:
- Local postgresql instructions for running in a container
- LDAPWrapper to allow mocking accounts and decouple from ldap
- Prevents errors by disabling onesignal if secrets aren't configured
- Expands the logging on initialisation a little to show more of what's running locally

SSO will need a wrapper or overrides for the core methods, similar to LDAPWrapper, which is beyond what I'm prepared to do at the moment.

This should make hacktoberfest somewhat simpler, as well as making it easier to work in codespaces (though this is still heavily limited by sso).
