### PR TITLE
Add Codespace configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/vscode/devcontainers/universal:1-linux
+
+USER root
+
+# Add LDAP and python dependency build deps
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -yq --no-install-recommends install gcc curl libsasl2-dev libldap2-dev libssl-dev python3-dev
+
+USER codespace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,6 @@
 	"name": "Packet Codespace (python and postgres)",
 	"dockerComposeFile": "docker-compose.yaml",
 	"service": "app",
-  "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,59 @@
+// Update the VARIANT arg in docker-compose.yml to pick a Python version: 3, 3.8, 3.7, 3.6 
+{
+	"name": "Packet Codespace (python and postgres)",
+	"dockerComposeFile": "docker-compose.yaml",
+	"service": "app",
+  "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"sqltools.connections": [{
+			"name": "Container database",
+			"driver": "PostgreSQL",
+			"previewLimit": 50,
+			"server": "localhost",
+			"port": 5432,
+			"database": "postgres",
+			"username": "postgres",
+			"password": "mysecretpassword"
+		}],
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"python.pythonPath": "/opt/python/latest/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+		"python.testing.pytestPath": "/usr/local/py-utils/bin/pytest"
+	},
+	"remoteUser": "codespace",
+	"overrideCommand": false,
+	"workspaceMount": "source=${localWorkspaceFolder},target=/home/codespace/workspace,type=bind,consistency=cached",
+	"workspaceFolder": "/home/codespace/workspace",
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", "--privileged", "--init" ],
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"GitHub.vscode-pull-request-github",
+		"ms-python.python",
+		"mtxr.sqltools",
+		"mtxr.sqltools-driver-pg"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [5000, 5432],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "oryx build" will automatically install your dependencies and attempt to build your project
+  "postCreateCommand": [
+    "pip install --progress-bar=off install -r requirements.txt;",
+    "yarn install && `yarn bin gulp production`;",
+    "/home/codespace/.local/bin/flask db upgrade;"
+  ]
+}

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
         NODE_VERSION: "10"
 
     volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
       - ..:/workspace:cached
       
     # Overrides default command so things don't shut down after the process ends.

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,40 @@
+version: '3'
+
+services:
+  app:
+    build: 
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+      args:
+        NODE_VERSION: "10"
+
+    volumes:
+      - ..:/workspace:cached
+      
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+    
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Uncomment the next line to use a non-root user for all processes.
+    user: codespace
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: mysecretpassword
+
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward MongoDB locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  postgres-data:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Install ldap dependencies
-        run: sudo apt-get install libldap2-dev libsasl2-dev
+        run: sudo apt-get update && sudo apt-get install libldap2-dev libsasl2-dev
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2


### PR DESCRIPTION
Create a default codespaces config:
- Install dependencies (yarn and python)
- Setup a postgres db and run migrations
- Run gulp production

Between this and #216, when codespaces roll out to GA, it should be just about trivial to get a dev environment for packet setup. I think the only thing left to figure out is local sso mocking.

([Codespaces GA is planned for Q2, April-June](https://github.com/github/roadmap/projects/1#card-42486618))

TODOS:
- ~I will be squashing and rebasing these changes soon :TM:~ [pre squash branch](https://github.com/mxmeinhold/packet/tree/old-code-spaces) if you want to see the mess that this was
- SSO for local dev is kinda a separate beast and still on the longer term todo list (#233)
