### PR TITLE
Improved version strings

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.9]
 
     steps:
       - name: Install ldap dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster
+FROM python:3.9-slim-buster
 MAINTAINER Devin Matte <matted@csh.rit.edu>
 
 ENV DD_LOGS_INJECTION=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.7-slim-buster
 MAINTAINER Devin Matte <matted@csh.rit.edu>
 
+ENV DD_LOGS_INJECTION=true
+
 RUN apt-get -yq update && \
-    apt-get -yq --no-install-recommends install gcc curl libsasl2-dev libldap2-dev libssl-dev gnupg2 && \
+    apt-get -yq --no-install-recommends install gcc curl libsasl2-dev libldap2-dev libssl-dev gnupg2 git && \
     apt-get -yq clean all
 
 RUN mkdir /opt/packet
@@ -30,4 +32,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 
 RUN ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
 
-CMD ["ddtrace-run", "gunicorn", "packet:app", "--bind=0.0.0.0:8080", "--access-logfile=-", "--timeout=600"]
+# Set version for apm
+RUN echo "export DD_VERSION=$(git rev-parse --short HEAD)" >> ~/.bashrc
+
+CMD ["/bin/bash", "-c", "source ~/.bashrc && ddtrace-run gunicorn packet:app --bind=0.0.0.0:8080 --access-logfile=- --timeout=600"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 RUN ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
 
 # Set version for apm
-RUN echo "export DD_VERSION=$(git rev-parse --short HEAD)" >> ~/.bashrc
+RUN echo "export DD_VERSION=$(python3 packet/git.py)" >> /tmp/version
 
-CMD ["/bin/bash", "-c", "source ~/.bashrc && ddtrace-run gunicorn packet:app --bind=0.0.0.0:8080 --access-logfile=- --timeout=600"]
+CMD ["/bin/bash", "-c", "source /tmp/version && ddtrace-run gunicorn packet:app --bind=0.0.0.0:8080 --access-logfile=- --timeout=600"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSH Web Packet
 
-[![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-370/)
+[![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/downloads/release/python-390/)
 [![Build Status](https://travis-ci.com/ComputerScienceHouse/packet.svg?branch=develop)](https://travis-ci.com/ComputerScienceHouse/packet)
 
 Packet is used by CSH to facilitate the freshmen packet portion of our introductory member evaluation process. This is 
@@ -8,7 +8,7 @@ the second major iteration of packet on the web. The first version was
 [Tal packet](https://github.com/TalCohen/CSHWebPacket).
 
 ## Setup
-**Requires Python 3.7 or newer.**
+**Requires Python 3.9 or newer.**
 
 To get the server working you'll just need the Python dependencies and some secrets. There will be some UI issues due 
 to missing assets though. To solve that you'll want to set up the front end dependencies or download a copy of the 

--- a/packet/__init__.py
+++ b/packet/__init__.py
@@ -19,6 +19,8 @@ import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 
+from .git import get_version
+
 app = Flask(__name__)
 gzip = Gzip(app)
 
@@ -31,9 +33,8 @@ _pyfile_config = os.path.join(_root_dir, 'config.py')
 if os.path.exists(_pyfile_config):
     app.config.from_pyfile(_pyfile_config)
 
-# Fetch the version number from the npm package file
-with open(os.path.join(_root_dir, 'package.json')) as package_file:
-    app.config['VERSION'] = json.load(package_file)['version']
+# Fetch the version number
+app.config['VERSION'] = get_version()
 
 # Logger configuration
 logging.getLogger().setLevel(app.config['LOG_LEVEL'])

--- a/packet/git.py
+++ b/packet/git.py
@@ -1,0 +1,49 @@
+import json
+import os
+import subprocess
+
+def get_short_sha(commit_ish: str = 'HEAD'):
+    """
+    Get the short hash of a commit-ish
+    Returns '' if unfound
+    """
+
+    try:
+        rev_parse = subprocess.run(f'git rev-parse --short {commit_ish}'.split(), capture_output=True, check=True)
+        return rev_parse.stdout.decode('utf-8').strip()
+    except subprocess.CalledProcessError:
+        return ''
+
+def get_tag(commit_ish: str = 'HEAD'):
+    """
+    Get the name of the tag at a given commit-ish
+    Returns '' if untagged
+    """
+
+    try:
+        describe = subprocess.run(f'git describe --exact-match {commit_ish}'.split(), capture_output=True, check=True)
+        return describe.stdout.decode('utf-8').strip()
+    except subprocess.CalledProcessError:
+        return ''
+
+def get_version(commit_ish: str = 'HEAD'):
+    """
+    Get the version string of a commit-ish
+
+    If we have a commit and the commit is tagged, version is `tag (commit-sha)`
+    If we have a commit but not a tag, version is `commit-sha`
+    If we have neither, version is the version field of package.json
+    """
+
+    if sha := get_short_sha(commit_ish):
+        if tag := get_tag(commit_ish):
+            return f'{tag} ({sha})'
+        else:
+            return sha
+    else:
+        root_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+        with open(os.path.join(root_dir, 'package.json')) as package_file:
+            return json.load(package_file)['version']
+
+if __name__ == '__main__':
+    print(get_version())


### PR DESCRIPTION
Make the version string fancier, as well as defining DD_VERSION so we can track versions better in APM and RUM.

Using tags to generate version strings does mean we will need to tag new releases _before_ the OKD build starts. @devinmatte opinions on this? I can switch it back to using the package.json for the version number, if you'd rather keep using the webhook for builds.
