### PR TITLE
Patch 3.5.3-1: Fix DD_VERSION on prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 RUN ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
 
 # Set version for apm
-RUN echo "export DD_VERSION=$(python3 packet/git.py)" >> /tmp/version
+RUN echo "export DD_VERSION=\"$(python3 packet/git.py)\"" >> /tmp/version
 
 CMD ["/bin/bash", "-c", "source /tmp/version && ddtrace-run gunicorn packet:app --bind=0.0.0.0:8080 --access-logfile=- --timeout=600"]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "title": "CSH Packet",
   "name": "csh-packet",
-  "version": "3.5.3",
+  "version": "3.5.3-1",
   "description": "A web app implementation of the CSH introductory packet.",
   "bugs": {
     "url": "https://github.com/ComputerScienceHouse/packet/issues",


### PR DESCRIPTION
Unhandled spaces were causing pods to crash loop on init.