### PR TITLE
Actually count the number of upper sigs

### DIFF
--- a/packet/routes/upperclassmen.py
+++ b/packet/routes/upperclassmen.py
@@ -56,8 +56,8 @@ def upperclassmen_total(info=None):
             if sig.member not in upperclassmen:
                 upperclassmen[sig.member] = 0
 
-                if sig.signed:
-                    upperclassmen[sig.member] += 1
+            if sig.signed:
+                upperclassmen[sig.member] += 1
         for sig in packet.misc_signatures:
             misc[sig.member] = 1 + misc.get(sig.member, 0)
 


### PR DESCRIPTION
Because of this improperly nested for loop, we were only counting if a member had signed _any_ packets.