### PR TITLE
Trigger prod deploys on new `v*` tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,18 @@
 name: Trigger Builds on Release
-# Trigger builds on okd only on new releases
-# Assumes the branch is "master"
+# Trigger builds on okd only on new releases (tags starting with `v`)
 # Uses secrets.OKD_BUILD_HOOK to know where to send the event to
 # OKD_BUILD_HOOK should be a generic build hook
 
-on: 
-  release:
-    types:
-      - released
+on:
+  push:
+    tags:
+      - v*
 
 jobs:
   trigger_build:
     name: trigger build
     runs-on: ubuntu-latest
+
     steps:
       # Grab committer and author information from the commit
       - name: get commit


### PR DESCRIPTION
Turns out, you can trigger workflow's on tag pushes (I've learned this setting up the CD for https://github.com/mxmeinhold/pylint-fixme-info and https://github.com/mxmeinhold/decision-tree).

This pr should be the last step before we can drop this double branch setup, and move to prod being reflected by tags.
