### PR TITLE
Make report button readable

### DIFF
--- a/packet/templates/include/nav.html
+++ b/packet/templates/include/nav.html
@@ -32,7 +32,7 @@
                     {% endif %}
                 {% else %}
                     <li class="nav-item">
-                        <button id="freshman-report" class="btn btn-sm btn-default report-button">Report</button>
+                        <button id="freshman-report" class="btn btn-sm btn-primary report-button">Report</button>
                     </li>
                 {% endif %}
 


### PR DESCRIPTION
The grey text of button-default is barely readable against the pink background. White has much better contrast.
