### PR TITLE
active_packets: don't init datatables for intro realm

### DIFF
--- a/packet/templates/active_packets.html
+++ b/packet/templates/active_packets.html
@@ -112,5 +112,7 @@
 
 {% block scripts %}
     {{ super() }}
-    <script src="{{ url_for('static', filename='js/tables.min.js') }}"></script>
+    {% if info.realm == "csh" %}
+        <script src="{{ url_for('static', filename='js/tables.min.js') }}"></script>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
This should fix the first packet not having a sign button in the intro realm