### PR TITLE
Packet 3.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "title": "CSH Packet",
   "name": "csh-packet",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "description": "A web app implementation of the CSH introductory packet.",
   "bugs": {
     "url": "https://github.com/ComputerScienceHouse/packet/issues",


### PR DESCRIPTION
# Fixes:
* Revert upgrade of onesignal to 2.0.0 (#289)
* Protecting api routes from freshmen (#295)
* Fix the missing sign button for the first packet in intro realm (#309)
