### PR TITLE
Limit Freshmen Visible Entries

### DIFF
--- a/packet/routes/admin.py
+++ b/packet/routes/admin.py
@@ -36,7 +36,7 @@ def admin_packets(info=None):
 @before_request
 @log_time
 def admin_freshmen(info=None):
-    all_freshmen = Freshman.get_all()
+    all_freshmen = Freshman.query.limit(300).all()
 
     return render_template('admin_freshmen.html',
                            all_freshmen=all_freshmen,


### PR DESCRIPTION
/admin/freshmen literally cannot load before timing out because it is trying to generate all of the freshmen of the last 5 years. Evals doesn't need to see old freshmen accounts, and 300 is more than enough to see all current freshmen.

If you want me to make it smaller let me know, tbh I think even 150 would be fine