### PR TITLE
added catch for intro members w/o profile in nav

### DIFF
--- a/packet/templates/include/nav.html
+++ b/packet/templates/include/nav.html
@@ -41,7 +41,11 @@
                 <li class="navbar-user dropdown">
 
                     <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="user01">
-                        <img src="https://profiles.csh.rit.edu/image/{{ info.uid }}" onerror="this.src='https://gravatar.com/avatar/c000557e7f805c44b0cc0079db911f21.jpg?d=mm&s=250'">
+                        {% if info.realm == "csh" %}
+                        <img src="https://profiles.csh.rit.edu/image/{{ info.uid }}">
+                        {% else %}
+                        <img src="{{ get_rit_image(info.uid) }}">
+                        {% endif %}
                         {{ info.uid }}
                         <span class="caret"></span>
                     </a>

--- a/packet/templates/include/nav.html
+++ b/packet/templates/include/nav.html
@@ -41,7 +41,7 @@
                 <li class="navbar-user dropdown">
 
                     <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="user01">
-                        <img src="https://profiles.csh.rit.edu/image/{{ info.uid }}">
+                        <img src="https://profiles.csh.rit.edu/image/{{ info.uid }}" onerror="this.src='https://gravatar.com/avatar/c000557e7f805c44b0cc0079db911f21.jpg?d=mm&s=250'">
                         {{ info.uid }}
                         <span class="caret"></span>
                     </a>


### PR DESCRIPTION
while logic was in place to handle intro members without accounts on profiles.csh.rit.edu in the body there is none for the navbar. This is a potential fix. catches errors and directs them to the null@csh.rit.edu default profile picture

current behavior for intro member:
![nav](https://user-images.githubusercontent.com/64291507/186545765-90b717b9-1fc6-4d48-a9f0-ae1a24b95da0.PNG)
