### PR TITLE
Allow All Freshmen Signatures (for real this time)

### DIFF
--- a/packet/templates/active_packets.html
+++ b/packet/templates/active_packets.html
@@ -40,13 +40,17 @@
                                     {% for packet in packets %}
                                         <tr {% if packet.did_sign_result %}style="background-color: #4caf505e" {% endif %}>
                                             <td data-priority="1">
+                                                {% if info.is_upper %}
                                                 <a href="{{ url_for('freshman_packet', packet_id=packet.id) }}">
+                                                {% endif %}
                                                     <img class="eval-user-img"
                                                          alt="{{ get_rit_name(packet.freshman_username) }}"
                                                          src="{{ get_rit_image(packet.freshman_username) }}"
                                                          width="25"
                                                          height="25"/> {{ get_rit_name(packet.freshman_username) }}
+                                                {% if info.is_upper %}
                                                 </a>
+                                                {% endif %}
                                             </td>
                                             {% if info.is_upper %}
                                             <td data-sort="{{ packet.signatures_received_result.member_total }}">

--- a/packet/templates/packet.html
+++ b/packet/templates/packet.html
@@ -10,7 +10,7 @@
                     <h3>{{ get_rit_name(packet.freshman_username) }}</h3>
                 </div>
                 <div class="col">
-                    {% if not did_sign %}
+                    {% if not did_sign and info.ritdn != packet.freshman_username %}
                         <button class="btn btn-primary sign-button"
                                 data-packet_id="{{ packet.id }}"
                                 data-freshman_name="{{ get_rit_name(packet.freshman_username) }}">Sign
@@ -108,7 +108,7 @@
                 {% if info.is_upper or packet.freshman_username == info.ritdn %}
                 <div class="card mb-2">
                     <div class="card-header">
-                        <b>On-Floor Freshmen Signatures</b>
+                        <b>Freshmen Signatures</b>
                         {% if info.is_upper or packet.freshman_username == info.ritdn %}
                         <b class="signature-count">{{ received.fresh }}/{{ required.fresh }}</b>
                         {% else %}

--- a/packet/utils.py
+++ b/packet/utils.py
@@ -166,7 +166,7 @@ def create_new_packets(base_date: date, freshmen_list: dict) -> None:
     start = datetime.combine(base_date, packet_start_time)
     end = datetime.combine(base_date, packet_end_time) + timedelta(days=14)
 
-    print('Fetching data from LDAP...')
+    app.logger.info('Fetching data from LDAP...')
     all_upper = list(filter(
         lambda member: not ldap.is_intromember(member) and not ldap.is_on_coop(member), ldap.get_active_members()))
 
@@ -182,7 +182,7 @@ def create_new_packets(base_date: date, freshmen_list: dict) -> None:
     packets_starting_notification(start)
 
     # Create the new packets and the signatures for each freshman in the given CSV
-    print('Creating DB entries and sending emails...')
+    app.logger.info('Creating DB entries and sending emails...')
     for freshman in Freshman.query.filter(cast(Any, Freshman.rit_username).in_(freshmen_list)).all():
         packet = Packet(freshman=freshman, start=start, end=end)
         db.session.add(packet)
@@ -207,7 +207,7 @@ def create_new_packets(base_date: date, freshmen_list: dict) -> None:
 
 
 def sync_with_ldap() -> None:
-    print('Fetching data from LDAP...')
+    app.logger.info('Fetching data from LDAP...')
     all_upper = {member.uid: member for member in filter(
         lambda member: not ldap.is_intromember(member) and not ldap.is_on_coop(member), ldap.get_active_members())}
 
@@ -218,7 +218,7 @@ def sync_with_ldap() -> None:
     w_m = ldap.get_wiki_maintainers()
     drink = ldap.get_drink_admins()
 
-    print('Applying updates to the DB...')
+    app.logger.info('Applying updates to the DB...')
     for packet in Packet.query.filter(Packet.end > datetime.now()).all():
         # Update the role state of all UpperSignatures
         for sig in filter(lambda sig: sig.member in all_upper, packet.upper_signatures):


### PR DESCRIPTION
Actually allows all freshmen to sign each other's packets. Also contains improved logging through the packet creation process and removes the "Sign" button from a freshman's own page.
