### PR TITLE
Update badges.scss

### DIFF
--- a/frontend/scss/components/badges.scss
+++ b/frontend/scss/components/badges.scss
@@ -19,7 +19,7 @@ span {
 
     &.badge-wm {
         color: #fff;
-        background-color: #b19cd9;
+        background-color: #800040;
     }
 
     &.badge-webmaster {


### PR DESCRIPTION
Makes the Wiki Maintainers badge into a more accessible color (#800040) that has a higher accessibility score. This is according to issue #368.