### PR TITLE
Update tables.js

### DIFF
--- a/packet/static/js/tables.js
+++ b/packet/static/js/tables.js
@@ -3,30 +3,31 @@ $(document).ready(function () {
     $('#active_packets_table').DataTable({
         "searching": true,
         "order": [],
-        "scrollX": false,
+        "scrollX": true,
         "paging": false,
         "info": false,
+        "autoWidth": false,
         "columnDefs": [
             {
                 "targets": 0,
-                "max-width": "50%",
+                "width": "50%",
             },
             {
                 "type": "num-fmt",
                 "targets": 1,
                 "visible": false,
-                "max-width": "15%",
+                "width": "15%",
             },
             {
                 "type": "num-fmt",
                 "targets": 2,
                 "visible": false,
-                "max-width": "15%",
+                "width": "15%",
             },
             {
                 "type": "num-fmt",
                 "targets": 3,
-                "max-width": "15%",
+                "width": "15%",
             }
         ]
     });
@@ -47,6 +48,9 @@ $(document).ready(function () {
             table.DataTable().column(2).visible(true);
             table.DataTable().column(3).visible(false);
         }
+        
+        // Prevent table shifting by adjusting columns
+        table.DataTable().columns.adjust();
     });
 
 });


### PR DESCRIPTION
# Fix: Prevent Freshman Table from Shifting When Switching Dropdown Options

## Description
This PR fixes issue #394 where the freshman packets table was shifting rightward out of frame when switching between dropdown options in the signature filter.

## Problem
When users switched between dropdown options ("Total", "Upperclassmen", "Freshmen"), the DataTable would recalculate column widths automatically, causing the table to shift rightward and move out of the visible frame. This created a poor user experience as users had to scroll horizontally to see the table content.

## Solution
The fix involves several key changes to the `packet/static/js/tables.js` file:

### Changes Made:
1. **Enabled horizontal scrolling**: Changed `scrollX` from `false` to `true` to handle overflow gracefully
2. **Disabled automatic width calculation**: Added `autoWidth: false` to prevent DataTables from recalculating widths
3. **Fixed column widths**: Changed `max-width` to `width` in columnDefs for consistent sizing
4. **Added column adjustment**: Added `table.DataTable().columns.adjust()` after visibility changes to ensure proper rendering

### Code Changes:
```javascript
// Before
"scrollX": false,
"max-width": "50%",

// After  
"scrollX": true,
"autoWidth": false,
"width": "50%",